### PR TITLE
Updates mjlab dependency to latest main to pick up bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ uv run play Mjlab-Tracking-Flat-Pal-Talos-Play --wandb-run-path your-org/mjlab/r
   </tr>
 </table>
 
+
+## Changing the `mjlab` dependency (uv)
+
+Use one of the following:
+
+```bash
+# add mjlab (tracks the default branch HEAD at lock time)
+uv add "mjlab @ git+https://github.com/mujocolab/mjlab"
+
+# pin to a specific commit
+uv add "mjlab @ git+https://github.com/mujocolab/mjlab@<commit sha>"
+
+# use the latest PyPI release
+uv add mjlab
+
+# use a local editable checkout (best for local development)
+uv add "mjlab @ path/to/mjlab" --editable
+```
+
+After switching, make sure your lockfile is updated:
+
+```bash
+uv sync
+```
+
+
 ## Acknowledgements
 
 We're grateful to the people behind mjlab, PAL Robotics, MuJoCo Warp, Isaac Lab, and the [Inria HUCEBOT Team](https://team.inria.fr/hucebot/).

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ This repository showcase the implementation of [PAL](https://pal-robotics.com/)'
 > [!WARNING]
 > As mjlab is still in early development, this repository may be impacted by breaking changes. If an issue were to arise when running one of the scripts, feel free to open an issue or contribute to the project. Thank you for your understanding!
 
+
 ## What's mjlab?
 
 mjlab is a project to have the [Isaac Lab](https://isaac-sim.github.io/IsaacLab/main/index.html) API using [MjWarp](https://mujoco.readthedocs.io/en/latest/mjwarp/index.html) as the backend. If you’re wondering about the motivation behind it or how it differs from Newton, you can learn more about it [here](https://github.com/mujocolab/mjlab/blob/main/docs/motivation.md).
 
 It’s really easy to install, and sim-to-real has been tested successfully on the G1 and Go1 for RL locomotion and motion imitation, see the announcement [tweet](https://x.com/kevin_zakka/status/1972757435707424898?t=4Ho4ovrCAEOWTCxVG3BKrw&s=19) for videos.
+
 
 ## Quickstart
 
@@ -32,6 +34,7 @@ uv run play Mjlab-Velocity-Flat-Pal-Talos --agent zero # send zero actions to th
 uv run play Mjlab-Velocity-Flat-Pal-Talos --agent random # send random actions to the robot
 ```
 
+
 ### Velocity Tracking
 
 Train the policy.
@@ -45,6 +48,7 @@ Evaluate the policy.
 ```bash
 uv run play Mjlab-Velocity-Flat-Pal-Talos --wandb-run-path your-org/mjlab/run-id
 ```
+
 
 ### Motion Imitation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires = ["uv_build>=0.8.18,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.sources]
-mjlab = { git = "https://github.com/mujocolab/mjlab", rev = "cfe92fcb4cfefad168adcad7162c6dc24a4d9f96" }
+mjlab = { git = "https://github.com/mujocolab/mjlab" }
 
 [project.entry-points."mjlab.tasks"]
 pal_mjlab = "pal_mjlab.tasks"

--- a/uv.lock
+++ b/uv.lock
@@ -965,7 +965,7 @@ wheels = [
 [[package]]
 name = "mjlab"
 version = "0.1.0"
-source = { git = "https://github.com/mujocolab/mjlab?rev=cfe92fcb4cfefad168adcad7162c6dc24a4d9f96#cfe92fcb4cfefad168adcad7162c6dc24a4d9f96" }
+source = { git = "https://github.com/mujocolab/mjlab#58886d2f3a4d033e0a972fd32db365c4ebc42c2b" }
 dependencies = [
     { name = "moviepy" },
     { name = "mujoco" },
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mjlab", git = "https://github.com/mujocolab/mjlab?rev=cfe92fcb4cfefad168adcad7162c6dc24a4d9f96" },
+    { name = "mjlab", git = "https://github.com/mujocolab/mjlab" },
     { name = "ruff", specifier = ">=0.14.0" },
 ]
 


### PR DESCRIPTION
This PR updates the `mjlab` dependency to the latest commit on the default branch to include the bug fix merged in PR #355. Previously, we temporarily relied on a commit outside the default branch; this is no longer necessary now that the fix is upstream.

I also added brief README instructions on how to change the `mjlab` dependency to make development and iteration easier (cc @sofieblankers-wq).