### PR TITLE
Add mujoco_warp_io.patch file to patch the mujoco_warp cuda 12.4 issue

### DIFF
--- a/mujoco_warp_io.patch
+++ b/mujoco_warp_io.patch
@@ -1,0 +1,14 @@
+--- mujoco_warp/_src/io.py
++++ mujoco_warp/_src/io.py
+@@ -70,7 +70,10 @@ def put_model(
+     The model containing kinematic and dynamic information (device).
+   """
+   # check for compatible cuda toolkit and driver versions
+-  warp_util.check_toolkit_driver()
++  try:
++    warp_util.check_toolkit_driver()
++  except Exception as e:
++    print(f"Warning: {e}. This may cause errors when running simulations.")
+ 
+   # model: check supported features in array types
+   for field, field_type in (


### PR DESCRIPTION
This PR adds a patch file script that can be used by the internal script to apply the patch when screating the Singularity Image Format (SIF) when deployoing on the clusters that have the old driver version (< 12.4)