### PR TITLE
Removes height sensor from TALOS Velocity Flat task

### DIFF
--- a/src/pal_mjlab/tasks/velocity/talos/env_cfgs.py
+++ b/src/pal_mjlab/tasks/velocity/talos/env_cfgs.py
@@ -70,6 +70,8 @@ def pal_talos_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
   assert isinstance(twist_cmd, UniformVelocityCommandCfg)
   twist_cmd.viz.z_offset = 1.15
 
+  cfg.observations["actor"].terms["height_scan"] = None
+  cfg.observations["critic"].terms["height_scan"] = None
   cfg.observations["critic"].terms["foot_height"].params[
     "asset_cfg"
   ].site_names = site_names


### PR DESCRIPTION
Not really needed for this case and adds a lot of computing time. BTW, below is the current result of Velocity Tracking on Flat terrain. Rough terrain is unstable, most probably because it's using meshes instead of capsules as collision. Future improvements should aim to change that but it's not a priority since we don't have plan for sim2real on Talos.

https://github.com/user-attachments/assets/036395bc-d8c7-429e-a905-e17fd79430bd

