### PR TITLE
Set the density of capsule to zero

### DIFF
--- a/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo.xml
+++ b/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo.xml
@@ -12,7 +12,7 @@
       <default class="collision">
           <geom type="capsule" group="3" material="bright_orange" contype="1" conaffinity="1"/>
           <default class="foot_capsule">
-            <geom type="capsule" size="0.01"/>
+            <geom type="capsule" size="0.01" density="0"/>
           </default>
       </default>
     </default>

--- a/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_grippers.xml
+++ b/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_grippers.xml
@@ -9,7 +9,7 @@
     <default class="collision">
         <geom type="capsule" group="3" material="bright_orange" contype="1" conaffinity="1"/>
         <default class="foot_capsule">
-          <geom type="capsule" size="0.01"/>
+          <geom type="capsule" size="0.01" density="0"/>
         </default>
     </default>
   </default>

--- a/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_hands.xml
+++ b/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_hands.xml
@@ -9,7 +9,7 @@
     <default class="collision">
         <geom type="capsule" group="3" material="bright_orange" contype="1" conaffinity="1"/>
         <default class="foot_capsule">
-          <geom type="capsule" size="0.01"/>
+          <geom type="capsule" size="0.01" density="0"/>
         </default>
     </default>
   </default>

--- a/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_lower_body.xml
+++ b/src/pal_mjlab/robots/pal_kangaroo/xmls/kangaroo_lower_body.xml
@@ -12,7 +12,7 @@
       <default class="collision">
           <geom type="capsule" group="3" material="bright_orange" contype="1" conaffinity="1"/>
           <default class="foot_capsule">
-            <geom type="capsule" size="0.01"/>
+            <geom type="capsule" size="0.01" density="0"/>
           </default>
       </default>
     </default>


### PR DESCRIPTION
`inertiafromgeom` defaults to "auto" and  MuJoCo uses the explicit <inertial> when present, otherwise auto-computes from geoms. leg_right_foot_link and leg_right_ankle_link (and their left counterparts) have no <inertial> and their geoms have no density override, so MuJoCo falls back to the default 1000 kg/m³.

So, we have to set the density to 0 to not to have double inertia at the foot:

Current state:
<img width="889" height="438" alt="image" src="https://github.com/user-attachments/assets/a14c1baf-2c29-489b-8abf-99775004eeed" />


With the proposed fix:

<img width="678" height="293" alt="image" src="https://github.com/user-attachments/assets/6b062f07-0584-4445-b18d-25a947cf2220" />
