### PR TITLE
Update mjlab to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mjlab>=1.5.0",
+    "mjlab>=1.5.1",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1265,7 +1265,7 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "imageio-ffmpeg" },
@@ -1291,9 +1291,9 @@ dependencies = [
     { name = "wandb" },
     { name = "warp-lang" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/9a/537dcb2b33e117d3ff18bad8fd8a2d44ec3aade1a8b0867b020743473e62/mjlab-1.5.0.tar.gz", hash = "sha256:f34fc5766de7ba57088b0f9f0b09806163bcc60b15e4a5c5b23197cd96a53adf", size = 14103394, upload-time = "2026-06-28T23:08:43.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/23/f507df33f4f849813c26ed32fc95a12200cfae803a037f51c8b766849fc8/mjlab-1.5.1.tar.gz", hash = "sha256:f9d2454929f292e3fa625a010398b99318012ff4e71acda3e72d4fac3f28287a", size = 14107461, upload-time = "2026-07-15T17:17:39.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/23/38c0a1fe06e1ba1eae81d687cdba8d71f37589fe23fd79d4d78ee2994b6a/mjlab-1.5.0-py3-none-any.whl", hash = "sha256:93aa539d1c7d8e984a34b8855967d304dd14a01e60c95aa03d7ac71c228f070c", size = 14197519, upload-time = "2026-06-28T23:08:41.119Z" },
+    { url = "https://files.pythonhosted.org/packages/19/27/71b0bd6d2e020531df0d42ce5eaa8f94ac18b3c94c39f5f0ad33396b3155/mjlab-1.5.1-py3-none-any.whl", hash = "sha256:6c0910940a2ee9375608a39c09a84592315214b59fcdbd1ec9fd4186c7791131", size = 14203915, upload-time = "2026-07-15T17:17:36.182Z" },
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.10.0.1"
+version = "3.10.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1446,9 +1446,9 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
     { name = "warp-lang" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/e5/37d982ba8bdbad8455fb74da827aa4e8ea1b984db66171d4b66c458da985/mujoco_warp-3.10.0.1.tar.gz", hash = "sha256:adca3e740112bca1aaaa732556aad0f36fb3dea99f86abd22ee1232dc5e2b28d", size = 2046299, upload-time = "2026-06-26T15:59:41.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/b1/edd8743786263d756bb1ffded28ae211289334bbb1ad9729c40e6163b376/mujoco_warp-3.10.0.2.tar.gz", hash = "sha256:3fe8b5c68bd30eda31af45d1cbee42480a7d1c6e69a35733c5538445375fc570", size = 2066036, upload-time = "2026-07-13T18:24:40.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/32/9adafac9cf8133cebe5825b306be01ab9209ab0fb5a057cb29e4f5b23bd5/mujoco_warp-3.10.0.1-py3-none-any.whl", hash = "sha256:7a5871a5522796fa36ec5614dc214a180d4fc7de861e413ee1559d2cc4ec79f9", size = 2123960, upload-time = "2026-06-26T15:59:39.77Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dc/928040ff3b95b2156dada9b4388a96fb423385c091663bb7f49f662a2d62/mujoco_warp-3.10.0.2-py3-none-any.whl", hash = "sha256:9245c952cd49761dea3f7fdb4060ee816dca0db3f2f63b561a80a02d20c40464", size = 2147055, upload-time = "2026-07-13T18:24:39.203Z" },
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mjlab", specifier = ">=1.5.0" },
+    { name = "mjlab", specifier = ">=1.5.1" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.7.0" },
     { name = "torch", marker = "extra == 'cu128'", specifier = ">=2.7.0" },
 ]


### PR DESCRIPTION
https://github.com/mujocolab/mjlab/releases/tag/v1.5.1
 
> This is a small compatibility and bugfix release. The headline is that mjlab now requires MuJoCo Warp 3.10.0.2, which fixes qfrc_constraint being populated incorrectly across vectorized environments (https://github.com/mujocolab/mjlab/issues/1086). Earlier 3.10.0.x releases are no longer supported.

I think we should merge this without any trainings as this seems to be a critical bug