### PR TITLE
Fix the CUDA illegal memory access issue in mjlab 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mjlab>=1.5.1",
+    "mjlab @ git+https://github.com/mujocolab/mjlab@c8348ba27f156acfdadf46c1ecd3166e763b66f0",
     "moviepy"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "mjlab @ git+https://github.com/mujocolab/mjlab@c8348ba27f156acfdadf46c1ecd3166e763b66f0",
-    "moviepy"
+    "moviepy>=2.0"
 ]
 
 [build-system]
@@ -34,6 +34,9 @@ cpu = ["torch>=2.7.0"]
 conflicts = [
   [{extra = "cu128"}, {extra = "cpu"}],
 ]
+# moviepy 2.x caps pillow at <12 while mjviser (via mjlab) needs >=12.2.
+# The cap is precautionary; moviepy works with pillow 12, so lift it.
+override-dependencies = ["pillow>=12.2.0"]
 
 [tool.ruff]
 indent-width = 2

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,9 @@ conflicts = [[
     { package = "pal-mjlab", extra = "cu128" },
 ]]
 
+[manifest]
+overrides = [{ name = "pillow", specifier = ">=12.2.0" }]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1364,18 +1367,21 @@ wheels = [
 
 [[package]]
 name = "moviepy"
-version = "0.2.3.1"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
     { name = "imageio" },
+    { name = "imageio-ffmpeg" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
-    { name = "tqdm" },
+    { name = "pillow" },
+    { name = "proglog" },
+    { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/08/2b9b253cbdc5d09fbd844acd03810df6fba822f7b045710a5d7044a9275a/moviepy-0.2.3.1.tar.gz", hash = "sha256:c56165ec07315dfb94f23ed541b9099f6e1ffe7ff980f254ea2fe37355ee2b95", size = 115727, upload-time = "2017-04-05T03:50:04.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/61/15f9476e270f64c78a834e7459ca045d669f869cec24eed26807b8cd479d/moviepy-2.2.1.tar.gz", hash = "sha256:c80cb56815ece94e5e3e2d361aa40070eeb30a09d23a24c4e684d03e16deacb1", size = 58431438, upload-time = "2025-05-21T19:31:52.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/6d/1c5827d4cd24ab501c11940e2f46a5e170c73aae94d862edc208e0cd48b0/moviepy-0.2.3.1-py2.py3-none-any.whl", hash = "sha256:5188c506d43a881d606f0757df42ed73402d43ba1107c6a6b0550f8db8bc97fd", size = 119386, upload-time = "2017-04-05T03:50:01.991Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl", hash = "sha256:6b56803fec2ac54b557404126ac1160e65448e03798fa282bd23e8fab3795060", size = 129871, upload-time = "2025-05-21T19:31:50.11Z" },
 ]
 
 [[package]]
@@ -2031,7 +2037,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "mjlab", git = "https://github.com/mujocolab/mjlab?rev=c8348ba27f156acfdadf46c1ecd3166e763b66f0" },
-    { name = "moviepy" },
+    { name = "moviepy", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.7.0" },
     { name = "torch", marker = "extra == 'cu128'", specifier = ">=2.7.0" },
 ]
@@ -2163,6 +2169,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "proglog"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/af/c108866c452eda1132f3d6b3cb6be2ae8430c97e9309f38ca9dbd430af37/proglog-0.1.12.tar.gz", hash = "sha256:361ee074721c277b89b75c061336cb8c5f287c92b043efa562ccf7866cda931c", size = 8794, upload-time = "2025-05-09T14:36:18.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl", hash = "sha256:ccaafce51e80a81c65dc907a460c07ccb8ec1f78dc660cfd8f9ec3a22f01b84c", size = 6337, upload-time = "2025-05-09T14:36:16.798Z" },
 ]
 
 [[package]]
@@ -2456,6 +2474,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4,12 +4,16 @@ requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 conflicts = [[
     { package = "pal-mjlab", extra = "cpu" },
@@ -321,7 +325,8 @@ version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -393,10 +398,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -578,7 +586,8 @@ version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
@@ -592,10 +601,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
@@ -912,7 +924,8 @@ version = "8.38.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform != 'win32' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -939,10 +952,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform != 'win32' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -1266,7 +1282,7 @@ wheels = [
 [[package]]
 name = "mjlab"
 version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/mujocolab/mjlab?rev=c8348ba27f156acfdadf46c1ecd3166e763b66f0#c8348ba27f156acfdadf46c1ecd3166e763b66f0" }
 dependencies = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy" },
@@ -1289,11 +1305,8 @@ dependencies = [
     { name = "tyro" },
     { name = "viser" },
     { name = "wandb" },
-    { name = "warp-lang" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/85/23/f507df33f4f849813c26ed32fc95a12200cfae803a037f51c8b766849fc8/mjlab-1.5.1.tar.gz", hash = "sha256:f9d2454929f292e3fa625a010398b99318012ff4e71acda3e72d4fac3f28287a", size = 14107461, upload-time = "2026-07-15T17:17:39.515Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/27/71b0bd6d2e020531df0d42ce5eaa8f94ac18b3c94c39f5f0ad33396b3155/mjlab-1.5.1-py3-none-any.whl", hash = "sha256:6c0910940a2ee9375608a39c09a84592315214b59fcdbd1ec9fd4186c7791131", size = 14203915, upload-time = "2026-07-15T17:17:36.182Z" },
+    { name = "warp-lang", version = "1.15.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "warp-lang", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
 ]
 
 [[package]]
@@ -1351,21 +1364,18 @@ wheels = [
 
 [[package]]
 name = "moviepy"
-version = "2.2.1"
+version = "0.2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
     { name = "imageio" },
-    { name = "imageio-ffmpeg" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pillow" },
-    { name = "proglog" },
-    { name = "python-dotenv" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/61/15f9476e270f64c78a834e7459ca045d669f869cec24eed26807b8cd479d/moviepy-2.2.1.tar.gz", hash = "sha256:c80cb56815ece94e5e3e2d361aa40070eeb30a09d23a24c4e684d03e16deacb1", size = 58431438, upload-time = "2025-05-21T19:31:52.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/08/2b9b253cbdc5d09fbd844acd03810df6fba822f7b045710a5d7044a9275a/moviepy-0.2.3.1.tar.gz", hash = "sha256:c56165ec07315dfb94f23ed541b9099f6e1ffe7ff980f254ea2fe37355ee2b95", size = 115727, upload-time = "2017-04-05T03:50:04.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl", hash = "sha256:6b56803fec2ac54b557404126ac1160e65448e03798fa282bd23e8fab3795060", size = 129871, upload-time = "2025-05-21T19:31:50.11Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6d/1c5827d4cd24ab501c11940e2f46a5e170c73aae94d862edc208e0cd48b0/moviepy-0.2.3.1-py2.py3-none-any.whl", hash = "sha256:5188c506d43a881d606f0757df42ed73402d43ba1107c6a6b0550f8db8bc97fd", size = 119386, upload-time = "2017-04-05T03:50:01.991Z" },
 ]
 
 [[package]]
@@ -1463,7 +1473,8 @@ dependencies = [
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
-    { name = "warp-lang" },
+    { name = "warp-lang", version = "1.15.0", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "warp-lang", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/b1/edd8743786263d756bb1ffded28ae211289334bbb1ad9729c40e6163b376/mujoco_warp-3.10.0.2.tar.gz", hash = "sha256:3fe8b5c68bd30eda31af45d1cbee42480a7d1c6e69a35733c5538445375fc570", size = 2066036, upload-time = "2026-07-13T18:24:40.645Z" }
 wheels = [
@@ -1476,7 +1487,8 @@ version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1490,10 +1502,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -1506,7 +1521,8 @@ version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1573,10 +1589,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
 wheels = [
@@ -2011,7 +2030,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mjlab", specifier = ">=1.5.1" },
+    { name = "mjlab", git = "https://github.com/mujocolab/mjlab?rev=c8348ba27f156acfdadf46c1ecd3166e763b66f0" },
     { name = "moviepy" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.7.0" },
     { name = "torch", marker = "extra == 'cu128'", specifier = ">=2.7.0" },
@@ -2144,18 +2163,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
-]
-
-[[package]]
-name = "proglog"
-version = "0.1.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/af/c108866c452eda1132f3d6b3cb6be2ae8430c97e9309f38ca9dbd430af37/proglog-0.1.12.tar.gz", hash = "sha256:361ee074721c277b89b75c061336cb8c5f287c92b043efa562ccf7866cda931c", size = 8794, upload-time = "2025-05-09T14:36:18.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl", hash = "sha256:ccaafce51e80a81c65dc907a460c07ccb8ec1f78dc660cfd8f9ec3a22f01b84c", size = 6337, upload-time = "2025-05-09T14:36:16.798Z" },
 ]
 
 [[package]]
@@ -2323,7 +2330,8 @@ version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "accessible-pygments", marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2347,10 +2355,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "accessible-pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2445,15 +2456,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -2599,7 +2601,8 @@ version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2660,10 +2663,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2777,7 +2783,8 @@ version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2809,7 +2816,8 @@ version = "9.0.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2842,8 +2850,10 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2875,7 +2885,8 @@ version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "pydata-sphinx-theme", version = "0.15.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -2893,10 +2904,13 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "pydata-sphinx-theme", version = "0.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
@@ -3366,10 +3380,41 @@ wheels = [
 [[package]]
 name = "warp-lang"
 version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.nvidia.com/" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
+]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version >= '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform == 'darwin' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin') or (python_full_version < '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform == 'darwin' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+]
+wheels = [
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ee06e2e76bff84088a09e64315e71ed0e55e94c936ec664d7b05ebd56f66a363" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:95c169f28bd7d6c78ac4ad62e2df1e61a096033748f757157fa4551aed80d010" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3c0711b39ad98ff924d29654b028ec4eaa02330e207ae3efc72445e9cde05b34" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0-py3-none-win_amd64.whl", hash = "sha256:06ef42c3ce522749268056653ea253645eb4a96ca164af74ae5113f0d55a6970" },
+]
+
+[[package]]
+name = "warp-lang"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform != 'darwin' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128') or (sys_platform != 'darwin' and extra == 'extra-9-pal-mjlab-cpu' and extra == 'extra-9-pal-mjlab-cu128')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/a2/712bcea055b80135e20a7a142f5dc1fa617bf3b5557dd4cc3afcc1048ab4/warp_lang-1.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ee06e2e76bff84088a09e64315e71ed0e55e94c936ec664d7b05ebd56f66a363", size = 25048790, upload-time = "2026-07-07T22:26:18.532Z" },


### PR DESCRIPTION
```
$ uv run train Mjlab-Velocity-Flat-Pal-Kangaroo --env.scene.num-envs 4096 --agent.logger tensorboard --env.sim.mujoco.timestep 0.005 --env.decimation 4 --agent.save-interval 500 
      Built pal-mjlab @ file:///home/saikishor/reinforcement_learning/locomotion/pal_mjlab
Uninstalled 1 package in 0.35ms
Installed 1 package in 1ms
/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/tyro/_parsers.py:353: UserWarning: The field `env.observations.actor.terms` is annotated with type `dict[str, mjlab.managers.observation_manager.ObservationTermCfg]`, but the default value `{'base_lin_vel': None, 'base_ang_vel': ObservationTermCfg(func=<function builtin_sensor at 0x78b8bf12f380>, params={'sensor_name': 'robot/imu_ang_vel'}, noise=UniformNoiseCfg(operation='add', n_min=-0.2, n_max=0.2), clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'projected_gravity': None, 'joint_pos': ObservationTermCfg(func=<function joint_pos_rel at 0x78b8bf12f100>, params={}, noise=UniformNoiseCfg(operation='add', n_min=-0.01, n_max=0.01), clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'joint_vel': ObservationTermCfg(func=<function joint_vel_rel at 0x78b8bf12f1a0>, params={}, noise=UniformNoiseCfg(operation='add', n_min=-0.5, n_max=0.5), clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'actions': ObservationTermCfg(func=<function last_action at 0x78b8bf12f240>, params={}, noise=None, clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'command': ObservationTermCfg(func=<function generated_commands at 0x78b8bf12f2e0>, params={'command_name': 'twist'}, noise=None, clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'height_scan': None, 'imu_projected_gravity': ObservationTermCfg(func=<function imu_projected_gravity at 0x78b8b0311300>, params={'sensor_name': 'robot/imu_quat'}, noise=UniformNoiseCfg(operation='add', n_min=-0.05, n_max=0.05), clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True), 'base_lin_acc': ObservationTermCfg(func=<function builtin_sensor at 0x78b8bf12f380>, params={'sensor_name': 'robot/imu_lin_acc'}, noise=UniformNoiseCfg(operation='add', n_min=-0.5, n_max=0.5), clip=None, scale=None, delay_min_lag=0, delay_max_lag=0, delay_per_env=True, delay_hold_prob=0.0, delay_update_period=0, delay_per_env_phase=True, history_length=0, flatten_history_dim=True)}` has type `<class 'dict'>`. We'll try to handle this gracefully, but it may cause unexpected behavior.
  warnings.warn(message)
/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/tyro/_resolver.py:600: TyroWarning: <class 'list'> does not match any type in Union: [<class 'str'>, <class 'tuple'>, <class 'NoneType'>]
  warnings.warn(
[INFO] Training with: device=cuda:0, seed=42, rank=0
[INFO] Logging experiment in directory: /home/saikishor/reinforcement_learning/locomotion/pal_mjlab/logs/rsl_rl/kangaroo_velocity/2026-07-17_10-57-03
Setting seed: 42
Warp 1.15.0 initialized:
   CUDA Toolkit 12.9, Driver 13.0
   Devices:
     "cpu"      : "x86_64"
     "cuda:0"   : "NVIDIA GeForce RTX 5060 Laptop GPU" (8 GiB, sm_120, mempool enabled)
   Kernel cache:
     /home/saikishor/.cache/warp/1.15.0
Module mujoco_warp._src.smooth 91c07ed load on device 'cuda:0' took 4412.19 ms  (compiled)
Module _nxn_broadphase__locals__kernel_cd21dc9b cd21dc9 load on device 'cuda:0' took 6.25 ms  (cached)
Module _primitive_narrowphase__locals__primitive_narrowphase_55c58d2c 55c58d2 load on device 'cuda:0' took 621.28 ms  (compiled)
Module mujoco_warp._src.constraint 36c8060 load on device 'cuda:0' took 5.69 ms  (cached)
Module _equality_connect__locals__kernel_886e541a 886e541 load on device 'cuda:0' took 3.15 ms  (cached)
Module _friction_dof__locals__kernel_0cd98302 0cd9830 load on device 'cuda:0' took 4.55 ms  (cached)
Module _limit_slide_hinge__locals__kernel_7e77232e 7e77232 load on device 'cuda:0' took 2.79 ms  (cached)
Module _efc_contact_init__locals__kernel_c85ef7c6 c85ef7c load on device 'cuda:0' took 2.30 ms  (cached)
Module _efc_contact_jac_dense__locals__kernel_5d1b69cd d78407b load on device 'cuda:0' took 472.38 ms  (compiled)
Module _efc_contact_update__locals__kernel_2d2d1a29 2d2d1a2 load on device 'cuda:0' took 3.93 ms  (cached)
Module mujoco_warp._src.sensor de892d8 load on device 'cuda:0' took 3770.79 ms  (compiled)
Module mujoco_warp._src.forward 35ed569 load on device 'cuda:0' took 1084.21 ms  (compiled)
Module mujoco_warp._src.passive d8c18c6 load on device 'cuda:0' took 1814.11 ms  (compiled)
Module mujoco_warp._src.forward ea2bb44 load on device 'cuda:0' took 1079.40 ms  (compiled)
Module _qfrc_smooth__locals__kernel_3ac7164a 3ac7164 load on device 'cuda:0' took 1.78 ms  (cached)
Module mujoco_warp._src.support ca784c5 load on device 'cuda:0' took 205.90 ms  (compiled)
Module _tile_cholesky_factorize_solve_block__locals__kernel_c25844f7 3dd1a16 load on device 'cuda:0' took 2936.99 ms  (compiled)
Module mujoco_warp._src.solver 85325a6 load on device 'cuda:0' took 1518.59 ms  (compiled)
Module _solve_init_jaref_kernel__locals__kernel_c576495d c576495 load on device 'cuda:0' took 127.06 ms  (compiled)
Module mul_m_kernel__locals___mul_m_4f80c25f 4f80c25 load on device 'cuda:0' took 4.21 ms  (cached)
Module _update_constraint_efc__locals__kernel_7b921a6e 7b921a6 load on device 'cuda:0' took 134.80 ms  (compiled)
Module _update_constraint_init_qfrc_constraint_dense__locals__kernel_87c13c1d 87c13c1 load on device 'cuda:0' took 118.87 ms  (compiled)
Module _update_gradient_zero_grad_dot__locals__kernel_f3cbc379 f3cbc37 load on device 'cuda:0' took 67.02 ms  (compiled)
Module _update_gradient_grad__locals__kernel_9e296ebd 9e296eb load on device 'cuda:0' took 78.84 ms  (compiled)
Module _update_gradient_JTDAJ_dense_tiled__locals__kernel_d6413311 3c12644 load on device 'cuda:0' took 567.50 ms  (compiled)
Module _update_gradient_cholesky__locals__kernel_d5ee2f5f b53e075 load on device 'cuda:0' took 2491.97 ms  (compiled)
Module _linesearch_iterative_kernel__locals__kernel_7e52c8ed 4ad8c79 load on device 'cuda:0' took 481.36 ms  (compiled)
Module _update_constraint_efc__locals__kernel_ddea4c95 ddea4c9 load on device 'cuda:0' took 144.12 ms  (compiled)
Module _update_constraint_init_qfrc_constraint_dense__locals__kernel_f58289d3 f58289d load on device 'cuda:0' took 120.30 ms  (compiled)
Module _update_gradient_zero_grad_dot__locals__kernel_59268b1c 59268b1 load on device 'cuda:0' took 80.68 ms  (compiled)
Module _update_gradient_grad__locals__kernel_af49475a af49475 load on device 'cuda:0' took 86.14 ms  (compiled)
Module _update_gradient_cholesky__locals__kernel_79498dcb 703fdcd load on device 'cuda:0' took 1336.57 ms  (compiled)
Module _solve_zero_search_dot__locals__kernel_410982cb 410982c load on device 'cuda:0' took 69.27 ms  (compiled)
Module _solve_search_update__locals__kernel_63d81555 63d8155 load on device 'cuda:0' took 104.80 ms  (compiled)
Module _contact_sort__locals__contact_sort_8d950af1 a76bf05 load on device 'cuda:0' took 4.74 ms  (cached)
Module mujoco_warp._src.derivative 833f5d0 load on device 'cuda:0' took 1256.43 ms  (compiled)
Module _next_time_builder__locals___next_time_8c8bbcbc 8c8bbcb load on device 'cuda:0' took 109.87 ms  (compiled)
Module reset_data__locals__reset_xfrc_applied_aec370af aec370a load on device 'cuda:0' took 4.10 ms  (cached)
Module reset_data__locals__reset_M_96396a8d 96396a8 load on device 'cuda:0' took 2.27 ms  (cached)
Module reset_data__locals__reset_mocap_b321694c b321694 load on device 'cuda:0' took 2.75 ms  (cached)
Module reset_data__locals__reset_contact_88cd7446 88cd744 load on device 'cuda:0' took 1.98 ms  (cached)
Module reset_data__locals__reset_sleep_1c5b28e7 1c5b28e load on device 'cuda:0' took 89.50 ms  (compiled)
Module reset_data__locals__reset_nworld_1ba8fb6e 1ba8fb6 load on device 'cuda:0' took 182.01 ms  (compiled)
Module mujoco_warp._src.render_util 97c6606 load on device 'cuda:0' took 5.99 ms  (cached)
Module mujoco_warp._src.bvh f2c5137 load on device 'cuda:0' took 4.77 ms  (cached)
Module mujoco_warp._src.ray afebb35 load on device 'cuda:0' took 6.25 ms  (cached)

+---------------------------------+
|         Base Environment        |
+------------------------+--------+
| Property               | Value  |
+------------------------+--------+
| Number of environments | 4096   |
| Environment device     | cuda:0 |
| Environment seed       | 42     |
| Physics step-size      | 0.005  |
| Environment step-size  | 0.02   |
+------------------------+--------+

[INFO] <EventManager> contains 3 active terms.
+-------------------------------------+
| Active Event Terms in Mode: 'reset' |
+--------+----------------------------+
| Index  | Name                       |
+--------+----------------------------+
|   0    | reset_base                 |
|   1    | reset_robot_joints         |
+--------+----------------------------+
+----------------------------------------------+
|    Active Event Terms in Mode: 'interval'    |
+-------+------------+-------------------------+
| Index | Name       | Interval time range (s) |
+-------+------------+-------------------------+
|   0   | push_robot |        (1.0, 3.0)       |
+-------+------------+-------------------------+
+---------------------------------------+
| Active Event Terms in Mode: 'startup' |
+--------+------------------------------+
| Index  | Name                         |
+--------+------------------------------+
|   0    | foot_friction                |
|   1    | encoder_bias                 |
|   2    | base_com                     |
|   3    | joint_friction               |
|   4    | leg_length_encoder_bias      |
+--------+------------------------------+
+-----------------------------+
| Domain Randomization Fields |
+-------+---------------------+
| Index | Field Name          |
+-------+---------------------+
|   0   | geom_friction       |
|   1   | body_ipos           |
|   2   | body_subtreemass    |
|   3   | dof_invweight0      |
|   4   | body_invweight0     |
|   5   | tendon_length0      |
|   6   | tendon_invweight0   |
|   7   | dof_frictionloss    |
+-------+---------------------+

Module repeat_array_kernel_f3ffbc3f f56645b load on device 'cuda:0' took 68.98 ms  (compiled)
Module repeat_array_kernel_f3ffbc3f 43f7a6f load on device 'cuda:0' took 83.62 ms  (compiled)
Module repeat_array_kernel_f3ffbc3f a5b1dbd load on device 'cuda:0' took 98.56 ms  (compiled)
[INFO] <CommandManager> contains 1 active terms.
+----------------------------------------+
|          Active Command Terms          |
+-------+-------+------------------------+
| Index | Name  |          Type          |
+-------+-------+------------------------+
|   0   | twist | UniformVelocityCommand |
+-------+-------+------------------------+

[INFO] <ActionManager> contains 1 active terms.
+---------------------------------+
| Active Action Terms (shape: 22) |
+-------+-----------+-------------+
| Index | Name      |   Dimension |
+-------+-----------+-------------+
|   0   | joint_pos |          22 |
+-------+-----------+-------------+

term: base_lin_vel set to None, skipping...
term: projected_gravity set to None, skipping...
term: height_scan set to None, skipping...
term: height_scan set to None, skipping...
[INFO] <ObservationManager> contains 2 groups.
+-----------------------------------------------------------+
| Active Observation Terms in Group: 'actor' (shape: (86,)) |
+----------+------------------------------------+-----------+
|  Index   | Name                               |   Shape   |
+----------+------------------------------------+-----------+
|    0     | base_ang_vel                       |    (3,)   |
|    1     | joint_pos                          |   (26,)   |
|    2     | joint_vel                          |   (26,)   |
|    3     | actions                            |   (22,)   |
|    4     | command                            |    (3,)   |
|    5     | imu_projected_gravity              |    (3,)   |
|    6     | base_lin_acc                       |    (3,)   |
+----------+------------------------------------+-----------+
+-------------------------------------------------------------+
| Active Observation Terms in Group: 'critic' (shape: (104,)) |
+----------+-------------------------------------+------------+
|  Index   | Name                                |   Shape    |
+----------+-------------------------------------+------------+
|    0     | base_lin_vel                        |    (3,)    |
|    1     | base_ang_vel                        |    (3,)    |
|    2     | projected_gravity                   |    (3,)    |
|    3     | joint_pos                           |   (26,)    |
|    4     | joint_vel                           |   (26,)    |
|    5     | actions                             |   (22,)    |
|    6     | command                             |    (3,)    |
|    7     | foot_height                         |    (2,)    |
|    8     | foot_air_time                       |    (2,)    |
|    9     | foot_contact                        |    (2,)    |
|    10    | foot_contact_forces                 |    (6,)    |
|    11    | imu_projected_gravity               |    (3,)    |
|    12    | base_lin_acc                        |    (3,)    |
+----------+-------------------------------------+------------+

[INFO] <TerminationManager> contains 4 active terms.
+------------------------------------------+
|         Active Termination Terms         |
+-------+-----------------------+----------+
| Index | Name                  | Time Out |
+-------+-----------------------+----------+
|   0   | time_out              |   True   |
|   1   | fell_over             |  False   |
|   2   | out_of_terrain_bounds |   True   |
|   3   | illegal_contacts      |  False   |
+-------+-----------------------+----------+

Convex hull equations device cuda:0
2D Convex hull comparison saved to: /tmp/convex_hull_comparison_hipXY.png
Convex hull equations device cuda:0
2D Convex hull comparison saved to: /tmp/convex_hull_comparison_ankleXY.png
[INFO] <RewardManager> contains 17 active terms.
+-------------------------------------------------+
|               Active Reward Terms               |
+-------+--------------------------------+--------+
| Index | Name                           | Weight |
+-------+--------------------------------+--------+
|   0   | track_linear_velocity          |    2.0 |
|   1   | track_angular_velocity         |    2.0 |
|   2   | upright                        |   1.25 |
|   3   | pose                           |    1.0 |
|   4   | body_ang_vel                   |  -0.05 |
|   5   | angular_momentum               |  -0.02 |
|   6   | dof_pos_limits                 |   -1.0 |
|   7   | action_rate_l2                 |   -0.1 |
|   8   | air_time                       |   0.25 |
|   9   | foot_clearance                 |   -2.0 |
|   10  | foot_swing_height              |  -0.25 |
|   11  | foot_slip                      |   -0.1 |
|   12  | soft_landing                   | -1e-05 |
|   13  | self_collisions                |   -1.0 |
|   14  | convex_hull_joint_limits_hip   |  -10.0 |
|   15  | convex_hull_joint_limits_ankle |  -10.0 |
|   16  | joint_vel_limits               |  -10.0 |
+-------+--------------------------------+--------+

[INFO] <CurriculumManager> contains 1 active terms.
+-------------------------+
| Active Curriculum Terms |
+--------+----------------+
| Index  | Name           |
+--------+----------------+
|   0    | command_vel    |
+--------+----------------+

[INFO] <MetricsManager> contains 6 active terms.
+------------------------------------------+
|           Active Metrics Terms           |
+-------+----------------------------------+
| Index | Name                             |
+-------+----------------------------------+
|   0   | joint_vel_mag                    |
|   1   | joint_acc_mag                    |
|   2   | joint_torque_mag                 |
|   3   | action_rate_l2                   |
|   4   | action_acc_l2                    |
|   5   | max_feet_delta_vel_along_gravity |
+-------+----------------------------------+

[INFO] <NullRecorderManager> (inactive)
Module mujoco_warp._src.io 466491b load on device 'cuda:0' took 1229.90 ms  (compiled)
Module _tile_cholesky_factorize_block__locals__kernel_1b7b315c cb0e151 load on device 'cuda:0' took 1099.89 ms  (compiled)
Module _tile_cholesky_solve_block__locals__kernel_054bb5c2 abc98c1 load on device 'cuda:0' took 867.09 ms  (compiled)
Traceback (most recent call last):
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/bin/train", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/scripts/train.py", line 254, in main
    launch_training(task_id=chosen_task, args=args)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/scripts/train.py", line 203, in launch_training
    run_train(task_id, args, log_dir)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/scripts/train.py", line 148, in run_train
    env = RslRlVecEnvWrapper(env, clip_actions=cfg.agent.clip_actions)
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/rl/vecenv_wrapper.py", line 25, in __init__
    self.env.reset()
    ~~~~~~~~~~~~~~^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/envs/manager_based_rl_env.py", line 369, in reset
    self._reset_idx(env_ids)
    ~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/envs/manager_based_rl_env.py", line 555, in _reset_idx
    self.sim.reset(env_ids)
    ~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/sim/sim.py", line 506, in reset
    self._reset_mask[env_ids] = True
    ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/saikishor/reinforcement_learning/locomotion/pal_mjlab/.venv/lib/python3.13/site-packages/mjlab/sim/sim_data.py", line 71, in __setitem__
    self._tensor[idx] = value
    ~~~~~~~~~~~~^^^^^
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)
Warp CUDA error 700: an illegal memory access was encountered (in function wp_free_device_async, /builds/omniverse/warp/warp/native/warp.cu:915)

```

Pinning mjlab to the fix introduced in https://github.com/mujocolab/mjlab/pull/1098 works