### PR TITLE
Removing custom targets and weights for foot_swing_height and foot_clearance rewards

### DIFF
--- a/src/pal_mjlab/docs/release_notes.rst
+++ b/src/pal_mjlab/docs/release_notes.rst
@@ -21,6 +21,13 @@ The changes below have landed on ``main`` since the ``v1.0.0`` tag
 New Features & Tasks
 ^^^^^^^^^^^^^^^^^^^^^
 
+- **Removing custom height targets and weights for foot_swing_height and
+  foot_clearance rewards in Kangaroo rough velocity task.** Removing values
+  optimized for rough terrains consisting mainly of structured stairs (where
+  high clearance must be encouraged). Experimentally, it has been proven
+  that they slow down the training process while not improving any of the metrics.
+  (`#111 <https://github.com/pal-robotics/pal_mjlab/pull/111>`_)
+
 - **New rough-terrain velocity tasks for the Kangaroo (full and lower
   body).** Adds ``Mjlab-Velocity-Rough-Pal-Kangaroo`` and
   ``Mjlab-Velocity-Rough-Pal-Kangaroo-Lower-Body`` on top of the baseline

--- a/src/pal_mjlab/tasks/velocity/kangaroo/env_cfgs.py
+++ b/src/pal_mjlab/tasks/velocity/kangaroo/env_cfgs.py
@@ -408,14 +408,6 @@ def pal_kangaroo_rough_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
 
   ### REWARDS
 
-  # Swing height: stronger to avoid dragging the feet
-  cfg.rewards["foot_swing_height"].weight = -0.5
-  cfg.rewards["foot_swing_height"].params["target_height"] = 0.15
-
-  # Target clearance when moving: conservatively high to avoid stumbling
-  # Experimentally, increasing its weight makes the robot unstable
-  cfg.rewards["foot_clearance"].params["target_height"] = 0.15
-
   # More human-like air time and stronger, specially important with obstacles
   cfg.rewards["air_time"].weight = 1.0
   cfg.rewards["air_time"].params["threshold_min"] = 0.2


### PR DESCRIPTION
This custom values were a leftover of stairs-focused environments, and only needed to clear +15cm obstacles. For generic rough, the actually make learning slower and are completely not needed. Blue is an ablation with exactly the changes in this MR.

<img width="902" height="449" alt="image" src="https://github.com/user-attachments/assets/afa8dda7-da46-4ec7-a350-d3bae0fdcea3" />
<img width="902" height="449" alt="image" src="https://github.com/user-attachments/assets/730c1904-f2eb-41b6-b4e7-068e8cd8d501" />
<img width="902" height="449" alt="image" src="https://github.com/user-attachments/assets/5bfbac31-6338-47f3-98dd-9d5771f254dd" />
